### PR TITLE
Passing PVC annotations to external flex provisioner

### DIFF
--- a/flex/cmd/flex-provisioner/main.go
+++ b/flex/cmd/flex-provisioner/main.go
@@ -40,7 +40,6 @@ var (
 )
 
 func main() {
-	flag.Set("logtostderr", "true")
 	flag.Parse()
 
 	if errs := validateProvisioner(*provisioner, field.NewPath("provisioner")); len(errs) != 0 {

--- a/flex/pkg/volume/driver-call.go
+++ b/flex/pkg/volume/driver-call.go
@@ -30,7 +30,9 @@ const (
 	provisionCmd = "provision"
 	deleteCmd    = "delete"
 
-	optionPVorVolumeName = "kubernetes.io/pvOrVolumeName"
+	// PV options are not allowed with domain name like k8s.io and
+	// kubernetes.io
+	optionPVorVolumeName = "pvOrVolumeName"
 )
 
 // ErrorTimeout defines the time error


### PR DESCRIPTION
Problem: PVC annotations can be used by external provisioner during
provisioning but as of now this is not done. Also, kbernetes domain
is reserved so that can't be used during volume provisioning.

Solution: Fixed by passing PVC annotations to provisioner. Removed
k8s.io and kubernetes domain while passing volume name to provisioner.

Tests:
1. Created PVC without any annotations.
2. Created PVC with annotations.