### PR TITLE
Don't print output message if PV deletion fails.

### DIFF
--- a/flex/pkg/volume/delete.go
+++ b/flex/pkg/volume/delete.go
@@ -38,10 +38,10 @@ func (p *flexProvisioner) Delete(volume *v1.PersistentVolume) error {
 
 	call := p.NewDriverCall(p.execCommand, deleteCmd)
 	call.AppendSpec(volume.Spec.FlexVolume.Options, nil)
-	output, err := call.Run()
+	_, err = call.Run()
 
 	if err != nil {
-		glog.Errorf("Failed to delete volume %s, output: %s, error: %s", volume, output.Message, err.Error())
+		glog.Errorf("Failed to delete volume %s, error: %s", volume, err.Error())
 		return err
 	}
 	return nil


### PR DESCRIPTION
Problem: nil pointer assertion. If device references are not cleared
or device is still busy device deletion can fail; causing panic.

Solution: Dont print output which is passed as nil in case of error.

Tests:
1. Tried above test case works fine now.